### PR TITLE
TM1 credentials are not stored in a separate file, config.ini

### DIFF
--- a/Create Objects/create and delete annotation.py
+++ b/Create Objects/create and delete annotation.py
@@ -2,8 +2,10 @@
 - Create a cell annotation at a fix location in a cube.
 - Get all annotations from a cube. 
 - Delete the annotation that was created
-
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import uuid
 
@@ -11,7 +13,7 @@ from TM1py.Services import TM1Service
 from TM1py.Objects import Annotation
 
 # connection to TM1 Server
-tm1 = TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True)
+tm1 = TM1Service(**config['tm1srv01'])
 
 # just a random text
 random_string = str(uuid.uuid4())

--- a/Create Objects/create chore.py
+++ b/Create Objects/create chore.py
@@ -3,6 +3,9 @@ Create a Chore.
 
 Assumption: Process 'import actuals' exists in TM1 model and has a parameter 'pRegion'
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import uuid
 from datetime import datetime
@@ -13,7 +16,7 @@ from TM1py.Objects import ChoreTask
 from TM1py.Services import TM1Service
 
 # connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     now = datetime.now()
     frequency = ChoreFrequency(days='7', hours='9', minutes='2', seconds='45')
     tasks = [ChoreTask(0, 'import_actuals', parameters=[{'Name': 'pRegion', 'Value': 'UK'}])]

--- a/Create Objects/create cube.py
+++ b/Create Objects/create cube.py
@@ -3,11 +3,14 @@ Create a cube with 4 dimensions: red, green, blue, yellow
 
 Assumption: Dimensions (red, green, blue, yellow) exist in tm1 model
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import Cube
 from TM1py.Services import TM1Service
 
 # connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     cube = Cube(name='Rubiks Cube', dimensions=['red', 'green', 'blue', 'yellow'], rules='')
     tm1.cubes.create(cube)

--- a/Create Objects/create dimension.py
+++ b/Create Objects/create dimension.py
@@ -1,3 +1,7 @@
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 from TM1py.Objects import Dimension, Element, ElementAttribute, Hierarchy
 from TM1py.Services import TM1Service
 
@@ -5,7 +9,7 @@ from TM1py.Services import TM1Service
 name = 'TM1py Region'
 
 # Connection to TM1. Needs IP, Port, Credentials, and SSL
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # create elements objects
     elements = [Element(name='Europe', element_type='Consolidated'),
                 Element(name='CH', element_type='Numeric'),

--- a/Create Objects/create process.py
+++ b/Create Objects/create process.py
@@ -1,12 +1,15 @@
 """
 Create a TI process in TM1
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import Process
 from TM1py.Services import TM1Service
 
 # connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     process_name = 'TM1py process'
 
     # create new Process in python

--- a/Create Objects/create subset.py
+++ b/Create Objects/create subset.py
@@ -3,23 +3,27 @@
 - Read the subset and its elements
 - Delete the subset in TM1
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import Subset
 from TM1py.Services import TM1Service
 
+dimension_name = "Region"
+subset_name = "TM1py Subset"
+elements = ['1', '2', '3']
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
-    subset_name = "Key Departments"
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # create subset
-    s = Subset(dimension_name='Plan_Department', subset_name=subset_name, alias='', elements=['200', '405', '410'])
+    s = Subset(dimension_name=dimension_name, subset_name=subset_name, alias='', elements=elements)
     tm1.dimensions.subsets.create(subset=s, private=True)
 
     # get it and print out the elements
-    s = tm1.dimensions.subsets.get(dimension_name='Plan_Department', subset_name=subset_name, private=True)
+    s = tm1.dimensions.subsets.get(dimension_name=dimension_name, subset_name=subset_name, private=True)
     print(s.elements)
 
     # delete it
-    tm1.dimensions.subsets.delete(dimension_name='Plan_Department', subset_name=subset_name, private=True)
+    tm1.dimensions.subsets.delete(dimension_name=dimension_name, subset_name=subset_name, private=True)
 

--- a/Create Objects/create user.py
+++ b/Create Objects/create user.py
@@ -1,11 +1,14 @@
 """
 Create a new user
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import User
 from TM1py.Services import TM1Service
 
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     u = User(name='Hodor Hodor', friendly_name='Hodor', groups=['Admin'], password='apple')
     tm1.security.create_user(u)

--- a/Create Objects/create view.py
+++ b/Create Objects/create view.py
@@ -3,13 +3,15 @@ Create a classic TM1 cube view
 
 Assumptions: all referenced subsets exist in TM1 Server. 
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import NativeView
 from TM1py.Services import TM1Service
 
 # establish connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     native_view = NativeView(cube_name='Plan_BudgetPlan',
                              view_name='TM1py View3')

--- a/Load Data/csv to cube.py
+++ b/Load Data/csv to cube.py
@@ -1,8 +1,11 @@
 """
 Read a csv file with ~ 1000000 lines and write the data to a cube
 Takes about 24 seconds.
-
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 import time
 
 from TM1py.Services import TM1Service
@@ -24,7 +27,7 @@ with open("plan_BudgetPlan.csv", "r") as file:
     cube = server_and_cube.split(":")[1][0:-1]
 
 # Push cellset to TM1
-with TM1Service(address="localhost", port=12354, user="admin", password="apple", ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     start = time.time()
     tm1.cubes.cells.write_values(cube, cellset)
     end = time.time()

--- a/Load Data/cube to cube.py
+++ b/Load Data/cube to cube.py
@@ -5,29 +5,15 @@ then copy it to Cube 'Plan_BudgetPlan' on Instance B.
 Assumption: Metadata (Cube and Dimensions) are in sync.
 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
-# Connection Parameters
-tm1_source_parameters = {
-    "address": "localhost",
-    "port": "12354",
-    "user": "admin",
-    "password": "apple",
-    "ssl": True
-}
-tm1_target_parameters = {
-    "address": "localhost",
-    "port": "9123",
-    "user": "admin",
-    "password": "apple",
-    "ssl": True
-}
-
 # Setup Connections
-tm1_source = TM1Service(**tm1_source_parameters)
-tm1_target = TM1Service(**tm1_target_parameters)
-
+tm1_source = TM1Service(**config['tm1srv01'])
+tm1_target = TM1Service(**config['tm1srv02'])
 
 # Query data from source TM1 model through MDX
 mdx = "SELECT " \

--- a/Load Data/fx rates to cube daily.py
+++ b/Load Data/fx rates to cube daily.py
@@ -10,20 +10,15 @@ Prerequisites:
     To install it, run in command line: pip install pandas_datareader
 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from datetime import datetime
 # type 'pip install pandas_datareader' into cmd if you don't have pandas_datareader installed
 import pandas_datareader.data as web
 
 from TM1py.Services import TM1Service
-
-
-# Connection parameters
-address = "localhost"
-port = 12354
-user = "admin"
-password = "apple"
-ssl = True
 
 # FX Cube Name
 cube_name = 'TM1py FX Rates'
@@ -65,7 +60,7 @@ for currency_ticker, currency_details in currency_pairs.items():
         coordinates = (currency_details["From"], currency_details["To"], str(date), 'Spot')
         cellset[coordinates] = value
 
-with TM1Service(address=address, port=port, user=user, password=password, ssl=ssl) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     tm1.cubes.cells.write_values(cube_name, cellset)
 
 

--- a/Load Data/fx rates to cube monthly.py
+++ b/Load Data/fx rates to cube monthly.py
@@ -8,6 +8,9 @@ Prerequisites:
 3. Add pandas_reader module:
     To install it, run in command line: pip install pandas_datareader
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import collections
 from datetime import datetime
@@ -16,12 +19,6 @@ import pandas_datareader.data as web
 
 from TM1py.Services import TM1Service
 
-# TM1 Parameters
-address = 'localhost'
-port = 12354
-user = 'admin'
-password = 'apple'
-ssl = True
 cube_name = 'TM1py FX Rates Monthly'
 currency_pairs = {
             'EXUSAL': {'From': 'USD', 'To': 'AUD', 'Invert': 'N'},
@@ -60,5 +57,5 @@ for currency_ticker, currency_details in currency_pairs.items():
             value = data.values[0]
         coordinates = (currency_details["From"], currency_details["To"], my_year, my_month, 'Month Close')
         cellset[coordinates] = value
-    with TM1Service(address=address, port=port, user=user, password=password, ssl=ssl) as tm1:
+    with TM1Service(**config['tm1srv01']) as tm1:
         tm1.cubes.cells.write_values(cube_name, cellset)

--- a/Load Data/gdp to cube.py
+++ b/Load Data/gdp to cube.py
@@ -7,12 +7,14 @@ Assumption:
 - quandl is installed
 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 # type 'pip install quandl' into cmd if you don't have quandl installed
 import quandl
 import math
 from TM1py.Services import TM1Service
-
 
 raw_data = quandl.get("FRED/GDP")
 
@@ -26,7 +28,7 @@ for tmstp, row_data in raw_data.iterrows():
     value = row_data.values[0]
     cellset[coordinates] = value
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     tm1.cubes.cells.write_values('TM1py Econ', cellset)
 
 

--- a/Load Data/sample setup.py
+++ b/Load Data/sample setup.py
@@ -6,20 +6,14 @@ Create all cubes and dimensions thar are required for the Load Data Samples:
 
 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import Cube, Dimension, Hierarchy, Element
 from TM1py.Services import TM1Service
 
 from datetime import timedelta, date
-
-
-# TM1 Connection Parameters
-address = 'localhost'
-port = 12354
-user = 'admin'
-password = 'apple'
-ssl = True
-
 
 # Time magic with python generator
 def daterange(start_date, end_date):
@@ -28,7 +22,7 @@ def daterange(start_date, end_date):
 
 
 # push data to TM1
-with TM1Service(address=address, port=port, user=user, password=password, ssl=ssl) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # ============================
     # create TM1 objects for fx rates sample

--- a/Load Data/stock prices to cube.py
+++ b/Load Data/stock prices to cube.py
@@ -8,9 +8,10 @@ Prerequisites:
     Run TM1py sample Load Data\setup.py
 2. Install quandl
     type 'pip install quandl' into cmd if you don't have quandl installed
-
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 # type 'pip install quandl' into cmd if you don't have quandl installed
 import quandl
 from TM1py.Services import TM1Service
@@ -28,6 +29,6 @@ for tmstp, row in data.iterrows():
         cellset[('IBM', str(date), measure)] = row[measure]
 
 # push data to TM1
-with TM1Service(address="", port="12354", user="admin", password="apple", ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     tm1.cubes.cells.write_values(cube, cellset)
 

--- a/Other/analyse cube rules.py
+++ b/Other/analyse cube rules.py
@@ -1,14 +1,15 @@
 """
 Read rules from all cubes and sort cubes by some metrics (Number rows, Number feeders,... )
-
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
 
 # Connect to TM1
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['source']) as tm1:
     cubes = tm1.cubes.get_all()
 
     # cubes with SKIPCHECK

--- a/Other/analyse cube rules.py
+++ b/Other/analyse cube rules.py
@@ -9,7 +9,7 @@ from TM1py.Services import TM1Service
 
 
 # Connect to TM1
-with TM1Service(**config['source']) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     cubes = tm1.cubes.get_all()
 
     # cubes with SKIPCHECK

--- a/Other/cleanup model.py
+++ b/Other/cleanup model.py
@@ -1,16 +1,17 @@
 """
 Remove all objects in TM1 that match a list of regular expressions.
-
 use with care!
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import re
 
 from TM1py.Services import TM1Service
 
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # Regular expression for everything that starts with 'temp_', 'test' or 'TM1py'
     regex_list = ['^temp_*', '^test*', '^TM1py*']

--- a/Other/create huge dimension.py
+++ b/Other/create huge dimension.py
@@ -1,9 +1,16 @@
+"""
+Create a new dimension TM1py Big dimension with 100,000 elements
+"""
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 from TM1py.Services import TM1Service
 from TM1py.Objects import Dimension, Hierarchy, Element
 from TM1py.Utils import Utils
 
 # Establish connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['source']) as tm1:
     # Create Elements, Edges and stuff in python
     elements = [Element('Element {}'.format(i), 'Numeric') for i in range(1, 100001)]
     elements.append(Element('Even', 'Consolidated'))

--- a/Other/create huge dimension.py
+++ b/Other/create huge dimension.py
@@ -10,7 +10,7 @@ from TM1py.Objects import Dimension, Hierarchy, Element
 from TM1py.Utils import Utils
 
 # Establish connection to TM1 Server
-with TM1Service(**config['source']) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # Create Elements, Edges and stuff in python
     elements = [Element('Element {}'.format(i), 'Numeric') for i in range(1, 100001)]
     elements.append(Element('Even', 'Consolidated'))

--- a/Other/delete all private mdx views.py
+++ b/Other/delete all private mdx views.py
@@ -11,7 +11,7 @@ from TM1py.Services import TM1Service
 
 cube = "Retail"
 
-with TM1Service(**config['source']) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     private_views, public_views = tm1.cubes.views.get_all(cube)
     for v in private_views:
         if isinstance(v, MDXView):

--- a/Other/delete all private mdx views.py
+++ b/Other/delete all private mdx views.py
@@ -1,19 +1,21 @@
 """
 Delete all private MDX Views
-
 Important: MDXViews can not be seen in Architect/ Perspectives
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import MDXView
 from TM1py.Services import TM1Service
 
+cube = "Retail"
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
-    private_views, public_views = tm1.cubes.views.get_all("Plan_BudgetPlan")
+with TM1Service(**config['source']) as tm1:
+    private_views, public_views = tm1.cubes.views.get_all(cube)
     for v in private_views:
         if isinstance(v, MDXView):
-            tm1.cubes.views.delete(cube_name="Plan_BudgetPlan", view_name=v.name, private=True)
+            tm1.cubes.views.delete(cube_name=cube, view_name=v.name, private=True)
 
 
 

--- a/Other/delete views subsets through regex.py
+++ b/Other/delete views subsets through regex.py
@@ -1,16 +1,16 @@
 """
 Remove all Views and Subsets in TM1 that match a list of regular expressions.
-
 use with care!
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import re
 
 from TM1py.Services import TM1Service
 
-
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # regular expression for everything that starts with 'temp_' or 'test_'
     regex_list = ['^temp_.*', '^test_.*']
 

--- a/Other/find unused dimensions.py
+++ b/Other/find unused dimensions.py
@@ -1,11 +1,14 @@
 """
 Find all dimensions, that are not used in cubes
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
 # Connect to TM1
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # get all dimensions
     all_dimensions = tm1.dimensions.get_all_names()
     # get all cubes

--- a/Other/find unused groups.py
+++ b/Other/find unused groups.py
@@ -1,12 +1,13 @@
 """
 Find all security groups, that are not used
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
-
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # Get all groups
     all_groups = tm1.security.get_all_groups()
 

--- a/Other/generate mdx from native view.py
+++ b/Other/generate mdx from native view.py
@@ -2,14 +2,21 @@
 Load existing cube view from TM1 into python. Then ask TM1py to generate the MDX Query from the cube view
 """
 
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 from TM1py.Services import TM1Service
 
+cube = 'General Ledger'
+view = 'P&L'
 
 # Establish connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['source']) as tm1:
 
     # Instantiate TM1py.NativeView object
-    nv = tm1.cubes.views.get_native_view('Plan_BudgetPlan', 'High Level Profit And Loss', private=False)
+    nv = tm1.cubes.views.get_native_view(cube, view, private=False)
 
     # Retrieve MDX from native view. Print it
     print(nv.MDX)
+

--- a/Other/generate mdx from native view.py
+++ b/Other/generate mdx from native view.py
@@ -12,7 +12,7 @@ cube = 'General Ledger'
 view = 'P&L'
 
 # Establish connection to TM1 Server
-with TM1Service(**config['source']) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # Instantiate TM1py.NativeView object
     nv = tm1.cubes.views.get_native_view(cube, view, private=False)

--- a/Other/get TM1 application.py
+++ b/Other/get TM1 application.py
@@ -1,7 +1,13 @@
+"""
+Create a new file out.xlsx from a TM1 application file.
+"""
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 from TM1py import TM1Service
 
-
-with TM1Service(address='localhost', port=8892, user='admin', password='apple', ssl=True, logging=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # path in TM1 Application-Tree
     path = 'Finance/P&L.xlsx'
 

--- a/Other/get number cube cells.py
+++ b/Other/get number cube cells.py
@@ -3,12 +3,16 @@ Query all cubes from TM1.
 For each cube calculate the number of potential cells.
 """
 
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 import json
 
 from TM1py.Services import TM1Service
 
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # New List to store the cube - number mapping
     cubes_with_cellnumber = []
     # Loop through cubes and do the math

--- a/Other/processing feeders time.py
+++ b/Other/processing feeders time.py
@@ -1,12 +1,15 @@
 """
-regenerate feeders for all cubes. Read the time it took from the MessageLog and print it out
+Regenerate feeders for all cubes.
+Read the time it took from the MessageLog and print it out
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import time as t
 from datetime import date, time, datetime
 
 from TM1py.Services import TM1Service
-
 
 # Time magic with python
 def get_time_from_tm1_timestamp(tm1_timestamp):
@@ -20,7 +23,7 @@ def get_time_from_tm1_timestamp(tm1_timestamp):
     return datetime.combine(date(year, month, day), time(hour, minute, second))
 
 # Connect to TM1
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     for cube in tm1.cubes.get_all():
         if cube.has_rules and cube.rules.has_feeders:
             ti = 'CubeProcessFeeders(\'{}\');'.format(cube.name)

--- a/Other/reschedule all chores + 1 hour.py
+++ b/Other/reschedule all chores + 1 hour.py
@@ -3,10 +3,13 @@ Reschedule all chores by -1 Hour.
 Chores get deactivated implicitly before update (and activate after transaction is done)
 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 from TM1py.Services import TM1Service
 
-
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # Get all chores. Loop through them and update them
     for chore in tm1.chores.get_all():
         chore.reschedule(hours=-1)

--- a/Other/reuse sessionid.py
+++ b/Other/reuse sessionid.py
@@ -1,8 +1,12 @@
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 import time
 from TM1py.Services import TM1Service
 
 # Connect to TM1
-tm1 = TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True)
+tm1 = TM1Service(**config['tm1srv01'])
 print(tm1.server.get_server_name())
 # Save TM1Service instance to file
 tm1.save_to_file('tm1_connection')

--- a/Other/run TI Processes in parallel.py
+++ b/Other/run TI Processes in parallel.py
@@ -2,6 +2,9 @@
 Run Processes in parallel.
 Requires Python 3.5 or greater
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import asyncio
 
@@ -27,7 +30,7 @@ def run_process(tm1, region):
 async def main():
     loop = asyncio.get_event_loop()
     # Connect to TM1
-    with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+    with TM1Service(**config['tm1srv01']) as tm1:
         # Fire of different process executions though 'run_process' function.
         futures = [loop.run_in_executor(None, run_process, tm1, 'pRegion ' + regions[num])
                    for num

--- a/Other/run TI code.py
+++ b/Other/run TI code.py
@@ -1,11 +1,13 @@
 """
 Run loose statements of TI
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # Sample 1
     ti_statements = [

--- a/Other/tm1 rest api stress test.py
+++ b/Other/tm1 rest api stress test.py
@@ -1,9 +1,14 @@
 """
 Do REST API operations in parallel. Can be handy when troubleshooting REST API bugs.
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import asyncio
+
+cube = "General Ledger"
+view = "Default"
 
 from TM1py.Services import TM1Service
 
@@ -27,12 +32,12 @@ def get_all_process_names(tm1):
 
 def read_pnl(tm1):
     for i in range(1000):
-        data = tm1.cubes.cells.execute_view('Plan_BudgetPlan', 'High Level Profit and Loss', private=False)
+        data = tm1.cubes.cells.execute_view(cube, view, private=False)
 
 # fire requests asynchronously
 async def main():
     loop = asyncio.get_event_loop()
-    with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+    with TM1Service(**config['tm1srv01']) as tm1:
 
         future1 = loop.run_in_executor(None, execute_mdx, tm1)
         future2 = loop.run_in_executor(None, get_server_name, tm1)

--- a/Other/transactionlog delta requests.py
+++ b/Other/transactionlog delta requests.py
@@ -1,32 +1,20 @@
+
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 import time
 
 from TM1py import TM1Service
 
-# TM1 Connection Parameters
-source = {
-    "address": '10.77.19.60',
-    "port": 12354,
-    "user": 'admin',
-    "password": 'apple',
-    "ssl": True,
-    "cube": 'c1',
-}
-
-target = {
-    "address": '10.77.19.60',
-    "port": 9699,
-    "user": 'admin',
-    "password": 'apple',
-    "ssl": False,
-    "cube": 'c1',
-}
-
+cube_source = "Retail"
+cube_target = "Retail"
 
 # Establish connection to TM1 Source
-with TM1Service(**source) as tm1_source:
+with TM1Service(**config['tm1srv01']) as tm1_source:
 
     # Start Change Tracking
-    tm1_source.server.initialize_transaction_log_delta_requests("Cube eq '" + source["cube"] + "'")
+    tm1_source.server.initialize_transaction_log_delta_requests("Cube eq '" + cube_source + "'")
 
     # Continuous checks
     def job():
@@ -35,8 +23,8 @@ with TM1Service(**source) as tm1_source:
             cellset = dict()
             for entry in entries:
                 cellset[tuple(entry["Tuple"])] = entry["NewValue"]
-            with TM1Service(**target) as tm1_target:
-                tm1_target.cubes.cells.write_values(target["cube"], cellset)
+            with TM1Service(**config['tm1srv02']) as tm1_target:
+                tm1_target.cubes.cells.write_values(cube_target, cellset)
 
 
     while True:

--- a/Other/transactionlog entries since timestamp.py
+++ b/Other/transactionlog entries since timestamp.py
@@ -1,9 +1,17 @@
+"""
+Get all TM1 transactions for all cubes starting to a specific date.
+"""
+
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
+
 from datetime import datetime
 
 from TM1py.Services import TM1Service
 
 
-with TM1Service(address='10.77.19.60', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # Timestamp for Message-Log parsing
     timestamp = datetime(year=2018, month=2, day=15, hour=16, minute=2, second=0)

--- a/Query Data/cube data into pandas dataframe.py
+++ b/Query Data/cube data into pandas dataframe.py
@@ -4,13 +4,15 @@ http://pandas.pydata.org/
 
 - Calculate statistical measures on dataset (mean, median, std)
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils
 
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # define MDX Query
     mdx = "SELECT {[plan_time].[Jan-2004]:[plan_time].[Dec-2004]} * {[plan_chart_of_accounts].[Revenue]," \
                   "[plan_chart_of_accounts].[COS], [plan_chart_of_accounts].[Operating Expense], " \

--- a/Query Data/cube view vs mdx.py
+++ b/Query Data/cube view vs mdx.py
@@ -4,15 +4,18 @@ Measure time to see which way is faster.
 
 Assumption: Cube 'Plan_BudgetPlan' has a view called 'PerformanceTest'
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import time
 
 from TM1py.Services import TM1Service
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
-    cube_name = 'Plan_BudgetPlan'
-    view_name = 'PerformanceTest'
+    cube_name = 'General Ledger'
+    view_name = 'Default'
 
     # Extract MDX from CubeView
     mdx = tm1.cubes.views.get_native_view(cube_name, view_name, private=False).MDX

--- a/Query Data/mdx stress test.py
+++ b/Query Data/mdx stress test.py
@@ -1,6 +1,9 @@
 """
 Do MDX Queries asynchronously. 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import asyncio
 
@@ -22,7 +25,7 @@ def execute_mdx(tm1, mdx):
 # Fire requests asynchronously
 async def main():
     loop = asyncio.get_event_loop()
-    with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+    with TM1Service(**config['tm1srv01']) as tm1:
 
         future1 = loop.run_in_executor(None, execute_mdx, tm1, mdx1)
         future2 = loop.run_in_executor(None, execute_mdx, tm1, mdx2)

--- a/Query Data/query data through mdx view.py
+++ b/Query Data/query data through mdx view.py
@@ -3,6 +3,9 @@ Create MDX View on }ClientGroups cube and query data through it.
 
 IMPORTANT: MDX Views can not be seen through Architect/Perspectives.
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import uuid
 
@@ -10,7 +13,7 @@ from TM1py.Objects import MDXView
 from TM1py.Services import TM1Service
 
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # Random text
     random_string = str(uuid.uuid4())
 

--- a/Query Data/query data through mdx.py
+++ b/Query Data/query data through mdx.py
@@ -2,11 +2,14 @@
 Query data through MDX
 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # Define mdx query
     mdx = "SELECT " \
           "NON EMPTY {TM1SUBSETALL( [}Clients] )} on ROWS, " \

--- a/Read Objects/get chore.py
+++ b/Read Objects/get chore.py
@@ -1,13 +1,16 @@
 """
 Get a chore from TM1
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
 # Connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # Read Chore:
-    c = tm1.chores.get('real chore')
+    c = tm1.chores.get('Cub.GeneralLedger.Demo')
 
     # Print out the tasks
     for task in c.tasks:

--- a/Read Objects/get cube.py
+++ b/Read Objects/get cube.py
@@ -1,12 +1,14 @@
 """
 Get a Cube from TM1
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
-
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
-    c = tm1.cubes.get('Rubiks Cube')
+with TM1Service(**config['tm1srv01']) as tm1:
+    c = tm1.cubes.get('General Ledger')
     print(c.name)
     print(c.dimensions)
     if c.has_rules:

--- a/Read Objects/get dimension.py
+++ b/Read Objects/get dimension.py
@@ -1,14 +1,16 @@
 """
 Get a random dimension from the TM1 mode and print out its details
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import random
 
 from TM1py.Services import TM1Service
 
-
 # Connection to TM1. Needs Address, Port, Credentials, and SSL
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # get random dimension from the model
     dimension_names = tm1.dimensions.get_all_names()

--- a/Read Objects/get process.py
+++ b/Read Objects/get process.py
@@ -1,11 +1,14 @@
 """
 Query a Process from the TM1 model
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
 # connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # read Process
     p = tm1.processes.get('TM1py process')
 

--- a/Read Objects/get subset.py
+++ b/Read Objects/get subset.py
@@ -1,27 +1,33 @@
 """
 Get private and public Subsets from TM1
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+dimension_name='Region'
+hierarchy_name='Region'
 
-    private_subsets = tm1.dimensions.subsets.get_all_names(dimension_name='plan_department',
-                                                           hierarchy_name='plan_department',
+with TM1Service(**config['tm1srv01']) as tm1:
+
+    private_subsets = tm1.dimensions.subsets.get_all_names(dimension_name=dimension_name,
+                                                           hierarchy_name=hierarchy_name,
                                                            private=True)
     print('private subsets: ')
     for subset_name in private_subsets:
-        subset = tm1.dimensions.subsets.get(dimension_name='plan_department',
+        subset = tm1.dimensions.subsets.get(dimension_name=dimension_name,
                                             subset_name=subset_name,
                                             private=True)
         print(subset.name)
 
-    public_subsets = tm1.dimensions.subsets.get_all_names(dimension_name='plan_department',
-                                                          hierarchy_name='plan_department',
+    public_subsets = tm1.dimensions.subsets.get_all_names(dimension_name=dimension_name,
+                                                          hierarchy_name=hierarchy_name,
                                                           private=False)
     print('public subsets: ')
     for subset_name in public_subsets:
-        subset = tm1.dimensions.subsets.get(dimension_name='plan_department',
+        subset = tm1.dimensions.subsets.get(dimension_name=dimension_name,
                                             subset_name=subset_name,
                                             private=False)
         print(subset.name)

--- a/Update Cells/write data fast.py
+++ b/Update Cells/write data fast.py
@@ -5,6 +5,9 @@ Script creates cube and dimensions by default if they don't exist yet.
 Play around with the number of working threads to find the optimal setup for your system!
 
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import asyncio
 import time
@@ -23,7 +26,7 @@ mdx_template = "SELECT " \
 
 # Create Dimensions and Cube, if it doesnt already exist
 def create_dimensions_and_cube():
-    with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+    with TM1Service(**config['tm1srv01']) as tm1:
         # Build Measure Dimension
         element = Element('Numeric Element', 'Numeric')
         hierarchy1 = Hierarchy('Python Cube Measure', 'Python Cube Measure', [element])

--- a/Update Cells/write data.py
+++ b/Update Cells/write data.py
@@ -1,11 +1,13 @@
 """
 Write data to TM1
 """
-
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # cellset to store the new data
     cellset = {}
     # Populate cellset with coordinates and value pairs

--- a/Update Objects/delete cube.py
+++ b/Update Objects/delete cube.py
@@ -1,8 +1,11 @@
 """ 
 Delete a cube
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     tm1.cubes.delete('Rubiks Cube')

--- a/Update Objects/update chore.py
+++ b/Update Objects/update chore.py
@@ -1,12 +1,15 @@
 """ 
 Get Chore form TM1. Update it. Push it back to TM1.
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Objects import ChoreFrequency
 from TM1py.Services import TM1Service
 
 # Connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # Read chore:
     c = tm1.chores.get('real chore')

--- a/Update Objects/update process.py
+++ b/Update Objects/update process.py
@@ -1,11 +1,14 @@
 """ 
 Get a Process from TM1. Update it. Push it back to TM1.
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 from TM1py.Services import TM1Service
 
 # connection to TM1 Server
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
     # read process
     p = tm1.processes.get('TM1py process')
 

--- a/Update Objects/update subset.py
+++ b/Update Objects/update subset.py
@@ -4,6 +4,9 @@
 - Push it back to TM1
 - Delete it
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import uuid
 
@@ -11,7 +14,7 @@ from TM1py.Objects import Subset
 from TM1py.Services import TM1Service
 
 
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # get a random string that we can use a subset name
     subset_name = str(uuid.uuid4())

--- a/Update Objects/update_dimension.py
+++ b/Update Objects/update_dimension.py
@@ -4,6 +4,9 @@ Get a dimension. Update it and push it back to TM1.
 IMPORTANT: Will not work TM1 11 due to bug in TM1
 https://www.ibm.com/developerworks/community/forums/html/topic?id=75f2b99e-6961-4c71-9364-1d5e1e083eff&ps=25
 """
+import configparser
+config = configparser.ConfigParser()
+config.read('..\config.ini')
 
 import uuid
 
@@ -11,7 +14,7 @@ from TM1py.Services import TM1Service
 
 
 # Connection to TM1. Needs Address, Port, Credentials, and SSL
-with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True) as tm1:
+with TM1Service(**config['tm1srv01']) as tm1:
 
     # get dimension
     dimension = tm1.dimensions.get('plan_department')

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,13 @@
+[source]
+address=localhost
+port=8802
+user=admin
+password=
+ssl=true
+
+[target]
+address=localhost
+port=8002
+user=admin
+password=
+ssl=true

--- a/config.ini
+++ b/config.ini
@@ -1,11 +1,11 @@
-[source]
+[tm1srv01]
 address=localhost
 port=8802
 user=admin
 password=
 ssl=true
 
-[target]
+[tm1srv02]
 address=localhost
 port=8002
 user=admin


### PR DESCRIPTION
Instead of setting the connection information to TM1 in each script:
with TM1Service(address='localhost', port=12354, user='admin', password='apple', ssl=True)

It is now stored in a separate file config.ini:
[tm1srv01]
address=localhost
port=8802
user=admin
password=
ssl=true

In every script we need now to import the file:
import configparser
config = configparser.ConfigParser()
config.read('..\config.ini')

and then use **config['tm1srv01'] to get the credentation