### PR TITLE
Return error message instead of stack and add defaults to input

### DIFF
--- a/check.py
+++ b/check.py
@@ -9,12 +9,12 @@ from TM1py.Services import TM1Service
 
 # Parameters for connection
 user = input("TM1 User (leave empty if SSO): ")
-password = getpass.getpass("Password (cmd doesn't show input, leave empty if SSO): ")
+password = getpass.getpass("Password (leave empty if SSO): ")
 namespace = input("CAM Namespace (leave empty if no CAM Security): ")
-address = input("Address (leave empty if localhost): ")
+address = input("Address (leave empty if localhost): ") or "localhost"
 gateway = input("ClientCAMURI (leave empty if no SSO): ")
-port = input("HTTP Port: ")
-ssl = strtobool(input("SSL (True or False): "))
+port = input("HTTP Port (Default 5000): ") or "5000"
+ssl = strtobool(input("SSL (Default T or F): ") or "T")
 
 if len(namespace.strip()) == 0:
     namespace = None
@@ -22,7 +22,8 @@ if len(namespace.strip()) == 0:
 if len(gateway.strip()) == 0:
     gateway = None
 
-with TM1Service(
+try:
+  with TM1Service(
         address=address,
         port=port,
         user=user,
@@ -32,3 +33,7 @@ with TM1Service(
         ssl=ssl) as tm1:
     server_name = tm1.server.get_server_name()
     print("Connection to TM1 established!! your Servername is: {}".format(server_name))
+except Exception as e:
+  print("\nERROR:")
+  print("\t" + str(e))
+


### PR DESCRIPTION
Hi @MariusWirtz,

Tweaked the check.py script to return a cleaner message instead of a stack trace and added some default to the port number and SSL. 